### PR TITLE
Fix Deserializing scalar date times

### DIFF
--- a/src/DateTimeSerializer.php
+++ b/src/DateTimeSerializer.php
@@ -64,6 +64,6 @@ class DateTimeSerializer
             return new \DateTime("{$value} 00:00:00");
         }
 
-        return \DateTime::createFromFormat(\DateTime::RFC3339, $value);
+        return \DateTime::createFromFormat($this->format, $value);
     }
 }

--- a/tests/DateTimeSerializerTest.php
+++ b/tests/DateTimeSerializerTest.php
@@ -101,4 +101,23 @@ class DateTimeSerializerTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals($dateTime->format(\DateTime::RSS), $actual);
     }
+
+    /**
+     * @test
+     */
+    public function willDeserializeValueUsingScalarSchemaUsingCustomDateTimeFormat()
+    {
+        $preciseDateTimeFormat = 'Y-m-d\TH:i:s.uP';
+        $preciseDateTime = '2010-01-01T23:45:59.000002+01:00';
+
+        $schemaDefinition = new \stdClass();
+        $schemaDefinition->format = Schema::FORMAT_DATE_TIME;
+
+        $schema = new ScalarSchema($schemaDefinition);
+
+        $serializer = new DateTimeSerializer($preciseDateTimeFormat);
+        $actualDate = $serializer->deserialize($preciseDateTime, $schema);
+
+        $this->assertEquals(\DateTime::createFromFormat($preciseDateTimeFormat, $preciseDateTime), $actualDate);
+    }
 }


### PR DESCRIPTION
When deserializing values, this class was applying a default datetime format, instead of using the one that was passed to the constructor of this class. Swagger API for example, allows to have extremely precise DateTime that include `DateTime::RFC3339`, but also allows for adding microseconds.

When deserializing such values, this class would lose that precision, as it was not taking into account the custom format.