### PR TITLE
Upgrade to phpunit 6.4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     "kleijnweb/php-api-descriptions": "^v1.0.0-alpha4@dev"
   },
   "require-dev": {
-    "phpunit/phpunit": "^5.2",
+    "phpunit/phpunit": "^6.4",
     "mikey179/vfsStream": "^1.6",
     "doctrine/cache": "^1.6",
     "satooshi/php-coveralls": "^1.0"

--- a/tests/ClassNameResolverTest.php
+++ b/tests/ClassNameResolverTest.php
@@ -11,29 +11,24 @@ namespace KleijnWeb\PhpApi\Hydrator\Tests;
 use KleijnWeb\PhpApi\Hydrator\ClassNameResolver;
 use KleijnWeb\PhpApi\Hydrator\Exception\ClassNotFoundException;
 use KleijnWeb\PhpApi\Hydrator\Tests\Types\Pet;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @author John Kleijn <john@kleijnweb.nl>
  */
-class ClassNameResolverTest extends \PHPUnit_Framework_TestCase
+class ClassNameResolverTest extends TestCase
 {
-    /**
-     * @test
-     */
-    public function canResolveExistingClass()
+    public function testCanResolveExistingClass()
     {
         $resolver = new ClassNameResolver([__NAMESPACE__ . '\\Types']);
-        $this->assertSame(Pet::class, $resolver->resolve('Pet'));
+        self::assertSame(Pet::class, $resolver->resolve('Pet'));
     }
 
-    /**
-     * @test
-     */
-    public function willThrowExceptionWhenClassNameIsNotResolvable()
+    public function testWillThrowExceptionWhenClassNameIsNotResolvable()
     {
         $resolver = new ClassNameResolver([__NAMESPACE__ . '\\Types']);
 
-        $this->setExpectedException(ClassNotFoundException::class);
+        self::expectException(ClassNotFoundException::class);
         $resolver->resolve('ProjectX');
     }
 }

--- a/tests/DateTimeSerializerTest.php
+++ b/tests/DateTimeSerializerTest.php
@@ -13,28 +13,23 @@ use KleijnWeb\PhpApi\Descriptions\Description\Schema\ScalarSchema;
 use KleijnWeb\PhpApi\Descriptions\Description\Schema\Schema;
 use KleijnWeb\PhpApi\Hydrator\DateTimeSerializer;
 use KleijnWeb\PhpApi\Hydrator\Exception\DateTimeNotParsableException;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @author John Kleijn <john@kleijnweb.nl>
  */
-class DateTimeSerializerTest extends \PHPUnit_Framework_TestCase
+class DateTimeSerializerTest extends TestCase
 {
-    /**
-     * @test
-     */
-    public function willSerializeDates()
+    public function testWillSerializeDates()
     {
         $date       = '2016-01-01';
         $serializer = new DateTimeSerializer();
         $schema     = new ScalarSchema((object)['type' => Schema::TYPE_STRING, 'format' => Schema::FORMAT_DATE]);
         $actual     = $serializer->serialize(new \DateTime($date), $schema);
-        $this->assertSame($date, $actual);
+        self::assertSame($date, $actual);
     }
 
-    /**
-     * @test
-     */
-    public function willDeserializeDatesToMidnight()
+    public function testWillDeserializeDatesToMidnight()
     {
         $serializer = new DateTimeSerializer();
         $schema     = new ScalarSchema((object)[
@@ -44,25 +39,19 @@ class DateTimeSerializerTest extends \PHPUnit_Framework_TestCase
 
         $actual                 = $serializer->deserialize('2016-01-01', $schema);
         $midnightFirstOfJanuary = new \DateTime('2016-01-01 00:00:00');
-        $this->assertSame('000000000000', $midnightFirstOfJanuary->diff($actual)->format('%Y%M%D%H%I%S'));
+        self::assertSame('000000000000', $midnightFirstOfJanuary->diff($actual)->format('%Y%M%D%H%I%S'));
     }
 
-    /**
-     * @test
-     */
-    public function willSerializeDateTime()
+    public function testWillSerializeDateTime()
     {
         $dateTime   = '2016-01-01T23:59:59.000000+01:00';
         $serializer = new DateTimeSerializer();
         $schema     = new ScalarSchema((object)['type' => Schema::TYPE_STRING, 'format' => Schema::FORMAT_DATE_TIME]);
 
-        $this->assertSame($dateTime, $serializer->serialize(new \DateTime($dateTime), $schema));
+        self::assertSame($dateTime, $serializer->serialize(new \DateTime($dateTime), $schema));
     }
 
-    /**
-     * @test
-     */
-    public function willDeserializeDateTime()
+    public function testWillDeserializeDateTime()
     {
         $dateTime   = '2016-01-01T23:59:59+01:00';
         $serializer = new DateTimeSerializer();
@@ -74,52 +63,40 @@ class DateTimeSerializerTest extends \PHPUnit_Framework_TestCase
         $actual                 = $serializer->deserialize($dateTime, $schema);
         $midnightFirstOfJanuary = new \DateTime($dateTime);
 
-        $this->assertSame('000000000000', $midnightFirstOfJanuary->diff($actual)->format('%Y%M%D%H%I%S'));
+        self::assertSame('000000000000', $midnightFirstOfJanuary->diff($actual)->format('%Y%M%D%H%I%S'));
     }
 
-    /**
-     * @test
-     */
-    public function willDeserializeValueUsingAnySchemaByUsingDateTimeConstructor()
+    public function testWillDeserializeValueUsingAnySchemaByUsingDateTimeConstructor()
     {
         $dateTime   = 'midnight';
         $serializer = new DateTimeSerializer();
         $schema     = new AnySchema();
         $actual     = $serializer->deserialize($dateTime, $schema);
 
-        $this->assertEquals(new \DateTime($dateTime), $actual);
+        self::assertEquals(new \DateTime($dateTime), $actual);
     }
 
-    /**
-     * @test
-     */
-    public function willSerializeValueUsingAnySchemaUsingDateTimeFormat()
+    public function testWillSerializeValueUsingAnySchemaUsingDateTimeFormat()
     {
         $dateTime   = new \DateTime('midnight');
         $serializer = new DateTimeSerializer(\DateTime::RSS);
         $schema     = new AnySchema();
         $actual     = $serializer->serialize($dateTime, $schema);
 
-        $this->assertEquals($dateTime->format(\DateTime::RSS), $actual);
+        self::assertEquals($dateTime->format(\DateTime::RSS), $actual);
     }
 
-    /**
-     * @test
-     */
-    public function willThrowExceptionWhenDateNotParsableAccordingToFormat()
+    public function testWillThrowExceptionWhenDateNotParsableAccordingToFormat()
     {
         $serializer = new DateTimeSerializer(\DateTime::RSS);
         $schema     = new ScalarSchema((object)['format' => Schema::FORMAT_DATE]);
 
-        $this->setExpectedException(DateTimeNotParsableException::class);
+        self::expectException(DateTimeNotParsableException::class);
 
         $serializer->deserialize('2016-01-01T23:59:59+01:00', $schema);
     }
 
-    /**
-     * @test
-     */
-    public function willDeserializeValueUsingScalarSchemaUsingCustomDateTimeFormat()
+    public function testWillDeserializeValueUsingScalarSchemaUsingCustomDateTimeFormat()
     {
         $preciseDateTimeFormat = 'm-d-Y\TH:i:s.uP';
         $preciseDateTime       = '01-01-2010T23:45:59.000002+01:00';
@@ -132,6 +109,6 @@ class DateTimeSerializerTest extends \PHPUnit_Framework_TestCase
         $serializer = new DateTimeSerializer($preciseDateTimeFormat);
         $actualDate = $serializer->deserialize($preciseDateTime, $schema);
 
-        $this->assertEquals(\DateTime::createFromFormat($preciseDateTimeFormat, $preciseDateTime), $actualDate);
+        self::assertEquals(\DateTime::createFromFormat($preciseDateTimeFormat, $preciseDateTime), $actualDate);
     }
 }

--- a/tests/ObjectHydratorTest.php
+++ b/tests/ObjectHydratorTest.php
@@ -21,11 +21,12 @@ use KleijnWeb\PhpApi\Hydrator\ObjectHydrator;
 use KleijnWeb\PhpApi\Hydrator\Tests\Types\Category;
 use KleijnWeb\PhpApi\Hydrator\Tests\Types\Pet;
 use KleijnWeb\PhpApi\Hydrator\Tests\Types\Tag;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @author John Kleijn <john@kleijnweb.nl>
  */
-class ObjectHydratorTest extends \PHPUnit_Framework_TestCase
+class ObjectHydratorTest extends TestCase
 {
     /**
      * @var ObjectHydrator
@@ -52,10 +53,7 @@ class ObjectHydratorTest extends \PHPUnit_Framework_TestCase
         $this->hydrator           = new ObjectHydrator($this->classNameResolver, $dateTimeSerializer);
     }
 
-    /**
-     * @test
-     */
-    public function canHyAndDehydratePet()
+    public function testCanHyAndDehydratePet()
     {
         $petSchema = $this->createFullPetSchema();
 
@@ -82,7 +80,7 @@ class ObjectHydratorTest extends \PHPUnit_Framework_TestCase
 
         $dateTime = new \DateTime();
         $this->dateTimeSerializer
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('deserialize')
             ->with($input->rating->created)
             ->willReturn($dateTime);
@@ -90,22 +88,22 @@ class ObjectHydratorTest extends \PHPUnit_Framework_TestCase
         /** @var Pet $pet */
         $pet = $this->hydrator->hydrate($input, $petSchema);
 
-        $this->assertInternalType('string', $input->rating->created);
+        self::assertInternalType('string', $input->rating->created);
 
-        $this->assertInstanceOf(Pet::class, $pet);
-        $this->assertInstanceOf(Category::class, $pet->getCategory());
-        $this->assertInternalType('int', $pet->getId());
-        $this->assertInternalType('array', $pet->getTags());
-        $this->assertInstanceOf(Tag::class, $pet->getTags()[0]);
-        $this->assertInternalType('string', $pet->getTags()[0]->getName());
-        $this->assertInstanceOf(Tag::class, $pet->getTags()[1]);
-        $this->assertInternalType('string', $pet->getTags()[1]->getName());
-        $this->assertInstanceOf(\stdClass::class, $pet->getRating());
-        $this->assertInternalType('int', $pet->getRating()->value);
-        $this->assertSame($dateTime, $pet->getRating()->created);
+        self::assertInstanceOf(Pet::class, $pet);
+        self::assertInstanceOf(Category::class, $pet->getCategory());
+        self::assertInternalType('int', $pet->getId());
+        self::assertInternalType('array', $pet->getTags());
+        self::assertInstanceOf(Tag::class, $pet->getTags()[0]);
+        self::assertInternalType('string', $pet->getTags()[0]->getName());
+        self::assertInstanceOf(Tag::class, $pet->getTags()[1]);
+        self::assertInternalType('string', $pet->getTags()[1]->getName());
+        self::assertInstanceOf(\stdClass::class, $pet->getRating());
+        self::assertInternalType('int', $pet->getRating()->value);
+        self::assertSame($dateTime, $pet->getRating()->created);
 
         $this->dateTimeSerializer
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('serialize')
             ->with($dateTime)
             ->willReturn($input->rating->created);
@@ -113,14 +111,10 @@ class ObjectHydratorTest extends \PHPUnit_Framework_TestCase
         $output = $this->hydrator->dehydrate($pet, $petSchema);
 
         unset($input->x);
-        $this->assertEquals($input, $output);
+        self::assertEquals($input, $output);
     }
 
-
-    /**
-     * @test
-     */
-    public function canDehydratePetWithAnySchema()
+    public function testCanDehydratePetWithAnySchema()
     {
         $dateTime       = new \DateTime('2016-01-01');
         $serializedDate = 'faux date-time';
@@ -134,7 +128,7 @@ class ObjectHydratorTest extends \PHPUnit_Framework_TestCase
         ]);
 
         $this->dateTimeSerializer
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('serialize')
             ->with($dateTime)
             ->willReturn($serializedDate);
@@ -142,24 +136,21 @@ class ObjectHydratorTest extends \PHPUnit_Framework_TestCase
         /** @var Pet $pet */
         $petAnonObject = $this->hydrator->dehydrate($pet, new AnySchema());
 
-        $this->assertInstanceOf(\stdClass::class, $petAnonObject);
-        $this->assertSame(1, $petAnonObject->id);
-        $this->assertSame($pet->getPhotoUrls(), $petAnonObject->photoUrls);
-        $this->assertSame($pet->getCategory()->getName(), $petAnonObject->category->name);
-        $this->assertSame($pet->getTags()[0]->getName(), $petAnonObject->tags[0]->name);
-        $this->assertSame($pet->getTags()[1]->getName(), $petAnonObject->tags[1]->name);
-        $this->assertSame($pet->getRating()->value, $petAnonObject->rating->value);
-        $this->assertSame($serializedDate, $petAnonObject->rating->created);
+        self::assertInstanceOf(\stdClass::class, $petAnonObject);
+        self::assertSame(1, $petAnonObject->id);
+        self::assertSame($pet->getPhotoUrls(), $petAnonObject->photoUrls);
+        self::assertSame($pet->getCategory()->getName(), $petAnonObject->category->name);
+        self::assertSame($pet->getTags()[0]->getName(), $petAnonObject->tags[0]->name);
+        self::assertSame($pet->getTags()[1]->getName(), $petAnonObject->tags[1]->name);
+        self::assertSame($pet->getRating()->value, $petAnonObject->rating->value);
+        self::assertSame($serializedDate, $petAnonObject->rating->created);
     }
 
-    /**
-     * @test
-     */
-    public function canHandleLargeArray()
+    public function testCanHandleLargeArray()
     {
         $size = 10000;
         $this->dateTimeSerializer
-            ->expects($this->any())
+            ->expects(self::any())
             ->method('deserialize')
             ->willReturnCallback(function ($value) {
                 return new\DateTime($value);
@@ -191,12 +182,9 @@ class ObjectHydratorTest extends \PHPUnit_Framework_TestCase
         $this->hydrator->hydrate($input, new ArraySchema((object)[], $this->createFullPetSchema()));
     }
 
-    /**
-     * @test
-     */
-    public function willThrowExceptionIfTryingToHydrateInt64On32BitOs()
+    public function testWillThrowExceptionIfTryingToHydrateInt64On32BitOs()
     {
-        $this->setExpectedException(UnsupportedException::class);
+        self::expectException(UnsupportedException::class);
 
         $petSchema = new ScalarSchema((object)['type' => 'integer', 'format' => Schema::FORMAT_INT64]);
 


### PR DESCRIPTION
> PHPUnit 5.7 is the old stable release series.
> It became stable on December 2, 2016.
> Support for PHPUnit 5 ends on February 2, 2018.
> — https://phpunit.de/